### PR TITLE
refactor(docker-compose): avoid redundant build of docker images for development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '3'
 services:
   mysql:
+    image: iidxio/mysql:dev
     build:
       context: .
       dockerfile: ./docker/mysql/Dockerfile.dev
@@ -17,6 +18,7 @@ services:
   redis:
     image: redis:4.0.12-stretch
   backend: &app_base
+    image: iidxio/backend:dev
     build:
       context: .
       dockerfile: ./docker/backend/Dockerfile.dev
@@ -50,6 +52,7 @@ services:
     stdin_open: false
     restart: on-failure:3
   frontend: &frontend
+    image: iidxio/frontend:dev
     build:
       context: .
       dockerfile: ./docker/frontend/Dockerfile.dev


### PR DESCRIPTION
This PR avoids redundant build of docker images for development.

The `spring` service and the `backend` service use different docker images, but these images are identical.
So we can use same images for these services.