### PR TITLE
fix(textage): make sure to set csv_title

### DIFF
--- a/backend/lib/textage/crawler.rb
+++ b/backend/lib/textage/crawler.rb
@@ -72,6 +72,7 @@ module Textage
 
       ::Music.new(
         title: title,
+        csv_title: title,
         genre: music_table.genre,
         artist: music_table.artist,
         textage_uid: uid,

--- a/backend/spec/textage/crawler_spec.rb
+++ b/backend/spec/textage/crawler_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe Textage::Crawler do
     it 'returns musics' do
       expect(subject).to contain_exactly have_attributes(
         title: 'A',
+        csv_title: 'A',
         genre: 'RENAISSANCE',
         artist: 'D.J.Amuro',
         textage_uid: 'a_amuro',


### PR DESCRIPTION
This commit fixes the following error:

```
ActiveRecord::NotNullViolation: Mysql2::Error: Field 'csv_title' doesn't have a default value
```