### PR TITLE
build(ci): stop building and pushing docker images on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,50 +105,6 @@ jobs:
           key: '{{ .Environment.CACHE_VERSION }}-yarn-{{ checksum "yarn.lock" }}'
       - run: yarn run format
 
-  build_frontend_docker_image:
-    docker:
-      - image: docker:18.06.3-ce-git
-    working_directory: /app
-    steps:
-      - checkout
-      - setup_remote_docker
-      - run:
-          name: Pull application Docker image
-          command: docker pull iidxio/frontend:latest
-      - run:
-          name: Build application Docker image
-          command: |
-            docker build --cache-from=iidxio/frontend:latest --build-arg IIDXIO_VERSION="$CIRCLE_SHA1" -t iidxio/frontend -f docker/frontend/Dockerfile.prod .
-            docker tag iidxio/frontend "iidxio/frontend:$CIRCLE_SHA1"
-      - deploy:
-          name: Push application Docker images
-          command: |
-            echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-            docker push "iidxio/frontend:$CIRCLE_SHA1"
-            docker push iidxio/frontend:latest
-
-  build_backend_docker_image:
-    docker:
-      - image: docker:18.06.1-ce-git
-    working_directory: /app
-    steps:
-      - checkout
-      - setup_remote_docker
-      - run:
-          name: Pull application Docker image
-          command: docker pull iidxio/backend:latest
-      - run:
-          name: Build application Docker image
-          command: |
-            docker build --cache-from=iidxio/backend:latest --build-arg IIDXIO_VERSION="$CIRCLE_SHA1" -t iidxio/backend -f docker/backend/Dockerfile.prod .
-            docker tag iidxio/backend "iidxio/backend:$CIRCLE_SHA1"
-      - deploy:
-          name: Push application Docker images
-          command: |
-            echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-            docker push "iidxio/backend:$CIRCLE_SHA1"
-            docker push iidxio/backend:latest
-
 workflows:
   version: 2
   build:
@@ -156,12 +112,3 @@ workflows:
       - build_frontend
       - build_backend
       - prettier
-      - build_frontend_docker_image: &build_docker_images
-          requires:
-            - build_frontend
-            - build_backend
-            - prettier
-          filters:
-            branches:
-              only: master
-      - build_backend_docker_image: *build_docker_images

--- a/docker/backend/hooks/build
+++ b/docker/backend/hooks/build
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+cd "$(dirname "$0")/../../.."
+
+docker build \
+  --build-arg "IIDXIO_VERSION=${SOURCE_COMMIT}" \
+  -t "${IMAGE_NAME}" \
+  -f "${DOCKERFILE_PATH}" \
+  .

--- a/docker/frontend/hooks/build
+++ b/docker/frontend/hooks/build
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+cd "$(dirname "$0")/../../.."
+
+docker build \
+  --build-arg "IIDXIO_VERSION=${SOURCE_COMMIT}" \
+  -t "${IMAGE_NAME}" \
+  -f "${DOCKERFILE_PATH}" \
+  .


### PR DESCRIPTION
* Migrate CircleCI to Docker Hub using Automated builds to build and push Docker images (`iidxio/frontend`, `iidxio/backend`).
* Stop tagging the images every commit.
  * The images are only attached `latest` tag.