### PR TITLE
fix(frontend): avoid creating an `auth` instance on build-time

### DIFF
--- a/frontend/__tests__/components/pages/signup.test.tsx
+++ b/frontend/__tests__/components/pages/signup.test.tsx
@@ -6,6 +6,14 @@ import * as renderer from 'react-test-renderer'
 import { FormValues } from '@app/components/organisms/LoginOrSignUpForm'
 import Signup from '@app/pages/signup'
 
+const mockCreate = jest.fn()
+
+jest.mock('@app/lib/firebaseApp', () => ({
+  auth: jest.fn().mockImplementation(() => ({
+    createUserWithEmailAndPassword: mockCreate,
+  })),
+}))
+
 const inputFields = (wrapper: ReactWrapper, values: FormValues) => {
   _.forEach(values, (value, key) => {
     wrapper
@@ -19,14 +27,6 @@ const submit = (wrapper: ReactWrapper) => {
 }
 
 describe('/signup', () => {
-  const mockCreate = jest.fn()
-
-  jest.mock('@app/lib/firebaseApp', () => ({
-    auth: jest.fn().mockImplementation(() => ({
-      createUserWithEmailAndPassword: mockCreate,
-    })),
-  }))
-
   beforeEach(() => {
     mockCreate.mockClear()
   })

--- a/frontend/__tests__/components/pages/signup.test.tsx
+++ b/frontend/__tests__/components/pages/signup.test.tsx
@@ -4,7 +4,6 @@ import * as React from 'react'
 import * as renderer from 'react-test-renderer'
 
 import { FormValues } from '@app/components/organisms/LoginOrSignUpForm'
-import { auth } from '@app/lib/firebaseApp'
 import Signup from '@app/pages/signup'
 
 const inputFields = (wrapper: ReactWrapper, values: FormValues) => {
@@ -20,8 +19,16 @@ const submit = (wrapper: ReactWrapper) => {
 }
 
 describe('/signup', () => {
+  const mockCreate = jest.fn()
+
+  jest.mock('@app/lib/firebaseApp', () => ({
+    auth: jest.fn().mockImplementation(() => ({
+      createUserWithEmailAndPassword: mockCreate,
+    })),
+  }))
+
   beforeEach(() => {
-    auth.createUserWithEmailAndPassword = jest.fn()
+    mockCreate.mockClear()
   })
 
   it('create a user on firebase auth', () => {
@@ -30,10 +37,7 @@ describe('/signup', () => {
     inputFields(wrapper, { email: 'email@example.com', password: 'password' })
     submit(wrapper)
 
-    expect(auth.createUserWithEmailAndPassword).toHaveBeenCalledWith(
-      'email@example.com',
-      'password',
-    )
+    expect(mockCreate).toHaveBeenCalledWith('email@example.com', 'password')
   })
 
   it('renders correctly', () => {

--- a/frontend/src/components/molecules/UserMenu/index.tsx
+++ b/frontend/src/components/molecules/UserMenu/index.tsx
@@ -64,7 +64,7 @@ const UserMenu: React.SFC<Props> = ({ displayName, className }) => {
           className={cx('item')}
           onClick={async () => {
             hide()
-            await auth.signOut()
+            await auth().signOut()
           }}
         >
           Sign out

--- a/frontend/src/components/pages/LoginPage/index.tsx
+++ b/frontend/src/components/pages/LoginPage/index.tsx
@@ -16,7 +16,7 @@ const cx = classnames.bind(css)
 
 const submitRequest: NonNullable<Props['submitRequest']> = values => {
   return new Promise((resolve, reject) => {
-    auth
+    auth()
       .signInWithEmailAndPassword(values.email, values.password)
       .then(() => resolve())
       .catch((e: ErrorType) => {

--- a/frontend/src/components/pages/SignupPage/index.tsx
+++ b/frontend/src/components/pages/SignupPage/index.tsx
@@ -16,7 +16,7 @@ const cx = classnames.bind(css)
 
 const submitRequest: NonNullable<Props['submitRequest']> = values => {
   return new Promise((resolve, reject) => {
-    auth
+    auth()
       .createUserWithEmailAndPassword(values.email, values.password)
       .then(() => resolve())
       .catch((e: ErrorType) => {

--- a/frontend/src/contexts/AuthStateProvider.tsx
+++ b/frontend/src/contexts/AuthStateProvider.tsx
@@ -30,7 +30,7 @@ class AuthStateProvider extends React.Component<Props, State> {
   public async componentDidMount() {
     await this.fetchViewer()
 
-    this.unsubscribe = auth.onAuthStateChanged(async user => {
+    this.unsubscribe = auth().onAuthStateChanged(async user => {
       if (user) {
         this.setState({ loading: true, signedIn: true })
       } else {

--- a/frontend/src/lib/firebaseApp/index.ts
+++ b/frontend/src/lib/firebaseApp/index.ts
@@ -1,5 +1,5 @@
 import app from './app'
 
-export const auth = app().auth()
+export const auth = () => app().auth()
 
 export type ErrorType = firebase.auth.Error

--- a/frontend/src/lib/initApollo.ts
+++ b/frontend/src/lib/initApollo.ts
@@ -32,8 +32,10 @@ const handleError = onError(({ graphQLErrors, networkError }) => {
 })
 
 const withAuthorization = setContext(async (_, { headers }) => {
-  if (auth.currentUser) {
-    const idToken = await auth.currentUser.getIdToken()
+  const currentUser = auth().currentUser
+
+  if (currentUser) {
+    const idToken = await currentUser.getIdToken()
 
     if (idToken) {
       return {


### PR DESCRIPTION
This commit fixes following error:

```
yarn run v1.13.0
$ NODE_ENV=production next build src
Creating an optimized production build ...
> Using external babel configuration
> Location: "/app/frontend/.babelrc"
> Build error occurred
{ [Error: Your API key is invalid, please check you have copied it correctly.]
code: 'auth/invalid-api-key',
message:
'Your API key is invalid, please check you have copied it correctly.' }
error Command failed with exit code 1.
```